### PR TITLE
Use strict dependency on Lodash

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.1.8",
   "main": "loader.js",
   "dependencies": {
-    "lodash": "*"
+    "lodash": "~3"
   },
   "devDependencies": {
     "qunit": "~1.12.0",


### PR DESCRIPTION
Commit f3073ad updated the invocation of `_.template` to specify an
"options" object as the second argument. This signature was introduced
in the 3.0.0 release of Lodash in such a way as to be incompatible with
usages in previous releases.

This amounts to a breaking change for consumers of this plugin. By
relying on the new API, this plugin should specify a strict dependency
of version 3.0 of the Lodash library.

[1] https://github.com/lodash/lodash/wiki/Changelog#v300